### PR TITLE
Apply make_clickable to comments

### DIFF
--- a/classes/front/api_helper.php
+++ b/classes/front/api_helper.php
@@ -58,8 +58,8 @@ class api_helper {
 		$time_format = get_option( 'time_format' );
 		$time = strtotime( $comment['comment_date'] );
 
-		//wpautop it
-		$comment[ 'comment_content' ] = wpautop( $comment[ 'comment_content' ] );
+		//filter content (make_clickable, wpautop, etc)
+		$comment[ 'comment_content' ] = apply_filters( 'comment_text', $comment[ 'comment_content' ] );
 
 		//add avatar markup as a string
 		$comment[ 'author_avatar' ] = get_avatar( $comment[ 'comment_author_email'], 48 );


### PR DESCRIPTION
Closes issue #10, but actually applies all comment_text filters, including wptexturize, wpautop, etc. I think this is good, but there might be things I'm not aware of.
