### PR TITLE
Move JS Comments Loaded Event to Proper Area

### DIFF
--- a/assets/js/front/epoch.js
+++ b/assets/js/front/epoch.js
@@ -391,6 +391,10 @@ jQuery( document ).ready( function ( $ ) {
                         html = app.parse_comment( comment );
                         app.put_comment_in_dom( html, comment.comment_parent, comment.depth, parseInt( comment.comment_ID, 10 ) );
                     });
+                    
+                    if ( !is_new ) {
+	                	  jQuery( 'body' ).triggerHandler( 'epoch.comments.loaded' );   
+	                }
 
 
                 }
@@ -422,8 +426,6 @@ jQuery( document ).ready( function ( $ ) {
                     response = app.get_data_from_response( response );
 
                     app.comment_response( response, true );
-                    
-                    jQuery( 'body' ).triggerHandler( 'epoch.comments.loaded' );
 
 
                 }

--- a/assets/js/front/epoch.js
+++ b/assets/js/front/epoch.js
@@ -392,9 +392,9 @@ jQuery( document ).ready( function ( $ ) {
                         app.put_comment_in_dom( html, comment.comment_parent, comment.depth, parseInt( comment.comment_ID, 10 ) );
                     });
                     
-                    if ( !is_new ) {
-	                	  jQuery( 'body' ).triggerHandler( 'epoch.comments.loaded' );   
-	                }
+					if ( !is_new ) {
+						jQuery( 'body' ).triggerHandler( 'epoch.comments.loaded' );   
+					}
 
 
                 }

--- a/assets/js/front/epoch.js
+++ b/assets/js/front/epoch.js
@@ -392,10 +392,9 @@ jQuery( document ).ready( function ( $ ) {
                         app.put_comment_in_dom( html, comment.comment_parent, comment.depth, parseInt( comment.comment_ID, 10 ) );
                     });
                     
-					if ( !is_new ) {
-						jQuery( 'body' ).triggerHandler( 'epoch.comments.loaded' );   
-					}
-
+                    if ( !is_new ) {
+                        jQuery( 'body' ).triggerHandler( 'epoch.comments.loaded' );   
+                    }
 
                 }
 


### PR DESCRIPTION
It looks like things were shuffled around in the JS with comment loading, and the event is no longer being run.

I've moved the event to the proper area where comments are now loaded. Assuming is_new is only false when comments are first loaded.

This isn't critical, as the comment posted event is still being run properly. The issue only exists on a page refresh. 

If you would like to try this out in the wild, I am using Epoch 1.0.3.1 with the modification in this pull request: http://www.ronalfy.com/epoch-test/

Thanks so much!
