### PR TITLE
Allow pingbacks to be shown

### DIFF
--- a/classes/front/api_helper.php
+++ b/classes/front/api_helper.php
@@ -247,13 +247,10 @@ class api_helper {
 			'post_id' => $post_id,
 			'order'   => $options['order'],
 			'status'  => 'approve',
+			'type'    => ! empty( $options['show_pings'] ) ? array( 'comment', 'pings' ) : array( 'comment' ),
 		);
 
-		if ( ! empty( $options['hide_pings'] ) ) {
-			$args['type'] = array( 'comment' );
-		}
-
-		return $args;
+		return apply_filters( 'epoch_comment_args', $args, $post_id );;
 
 	}
 

--- a/classes/front/api_helper.php
+++ b/classes/front/api_helper.php
@@ -249,6 +249,10 @@ class api_helper {
 			'status'  => 'approve',
 		);
 
+		if ( ! empty( $options['hide_pings'] ) ) {
+			$args['type'] = array( 'comment' );
+		}
+
 		return $args;
 
 	}
@@ -381,7 +385,7 @@ class api_helper {
 		if ( is_a( $author_user, 'WP_User' ) ) {
 			$classes = array_merge( $classes, $author_user->roles );
 		}
-		
+
 		if ( 1 != $comment['comment_approved'] ) {
 			$classes[] = 'epoch-wrap-comment-awaiting-moderation';
 		}
@@ -393,6 +397,30 @@ class api_helper {
 		}
 
 		return implode( ' ', $classes );
+	}
+
+	/**
+	 * Given a post ID determine the number of comments
+	 *
+	 * @since  1.0.5
+	 * @param  int $post_id The post ID
+	 * @return int          The comment count
+	 */
+	public static function get_comment_count( $post_id ) {
+		$options = options::get_display_options();
+		$count   = 0;
+
+		$comments = get_approved_comments( $post_id );
+
+		foreach ( $comments as $comment ) {
+
+			if ( $comment->comment_type === '' || ( $comment->comment_type === 'pingback' && empty( $options['hide_pings'] ) ) ) {
+				$count++;
+			}
+
+		}
+
+		return (int) $count;
 	}
 
 	/**

--- a/classes/front/api_process.php
+++ b/classes/front/api_process.php
@@ -26,9 +26,9 @@ class api_process {
 	 */
 	public static function get_comments( $data ) {
 
-		$args = api_helper::get_comment_args( $data[ 'postID' ] );
-
+		$args    = api_helper::get_comment_args( $data[ 'postID' ] );
 		$options = options::get_display_options();
+
 		$comments = get_comments( $args  );
 		if ( 'ASC' == $options[ 'order' ] ) {
 			$parents = array_combine( wp_list_pluck( $comments, 'comment_ID'),wp_list_pluck( $comments, 'comment_parent' ) );
@@ -71,14 +71,14 @@ class api_process {
 	 * @return array
 	 */
 	public static function comment_count( $data ) {
-		$count = wp_count_comments( $data[ 'postID' ] );
+
+		$count = api_helper::get_comment_count( $data[ 'postID'] );
+
 		if ( EPOCH_ALT_COUNT_CHECK_MODE ) {
 			api_helper::write_comment_count( $data[ 'postID' ], $count );
 		}
 
-		return array(
-			'count' => (int) $count->approved
-		);
+		return array( 'count' => $count );
 	}
 
 	/**

--- a/classes/front/templates/initial.php
+++ b/classes/front/templates/initial.php
@@ -11,9 +11,9 @@
 $options = \postmatic\epoch\options::get_display_options();
 global $post;
 
-$comment_count = get_comment_count( $post->ID );
+$comment_count = \postmatic\epoch\front\api_helper::get_comment_count( $post->ID );
 
-if ( $comment_count['approved'] == 0 and ! comments_open( $post ) ) {
+if ( $comment_count == 0 and ! comments_open( $post ) ) {
 	return;
 }
 
@@ -32,16 +32,16 @@ if ( 'none' == $options[ 'theme' ] ) {
 	$comment_count_area = '';
 }else{
 
-	if ( $comment_count['approved'] == 0 ) {
+	if ( $comment_count == 0 ) {
 		$comment_count_message = __( 'There are no comments', 'epoch' );
 	} else {
 		$comment_count_message = sprintf(
-			_n( 'There is one comment', 'There are %s comments', $comment_count['approved'], 'epoch' ),
-			'<span id="' . \postmatic\epoch\front\vars::$count_id . '">' . $comment_count['approved'] . '</span>'
+			_n( 'There is one comment', 'There are %s comments', $comment_count, 'epoch' ),
+			'<span id="' . \postmatic\epoch\front\vars::$count_id . '">' . $comment_count . '</span>'
 		);
 	}
 
-	if ( 'ASC' == $options['order'] && $comment_count['approved'] > 3 && 'iframe' != $options['theme'] ) {
+	if ( 'ASC' == $options['order'] && $comment_count > 3 && 'iframe' != $options['theme'] ) {
 		$comment_count_area = sprintf(
 			'<h3 class="comment-count-area">%1s <a href="#reply-title">%2s</a></h3>',
 			$comment_count_message,
@@ -59,7 +59,7 @@ if ( 'none' == $options[ 'theme' ] ) {
 		$comment_area = sprintf(
 		'<iframe id="%1s" src="' . get_permalink( $post->ID ) . 'epoch/" scrolling="no"></iframe>',
 		esc_attr( \postmatic\epoch\front\vars::$comments_wrap )
-		);		
+		);
 		$comment_count_area = $form = null;
 	}
 

--- a/classes/index.php
+++ b/classes/index.php
@@ -1,2 +1,7 @@
 <?php
+
 //silence is golden
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}

--- a/classes/options.php
+++ b/classes/options.php
@@ -65,7 +65,7 @@ class options {
 			'before_text' => __( 'Join the conversation', 'epoch' ),
 			'interval'    => 15,
 			'order'       => 'ASC',
-			'hide_pings'  => false,
+			'show_pings'  => false,
 		);
 
 		$options = wp_parse_args( $options, $defaults );

--- a/classes/options.php
+++ b/classes/options.php
@@ -64,7 +64,8 @@ class options {
 			'threaded'    => false,
 			'before_text' => __( 'Join the conversation', 'epoch' ),
 			'interval'    => 15,
-			'order'       => 'ASC'
+			'order'       => 'ASC',
+			'hide_pings'  => false,
 		);
 
 		$options = wp_parse_args( $options, $defaults );

--- a/includes/templates/options-panel.php
+++ b/includes/templates/options-panel.php
@@ -68,10 +68,10 @@
 
 <div class="epoch-config-group">
 	<label for="epoch-options-order">
-		<?php _e( 'Hide Pings & Trackbacks', 'epoch' ); ?>
+		<?php _e( 'Show Pings & Trackbacks', 'epoch' ); ?>
 	</label>
-	<input type="checkbox" name="options[hide_pings]" value="true" {{#is options/hide_pings value="true"}}checked{{/is}} />
+	<input type="checkbox" name="options[show_pings]" value="true" {{#is options/show_pings value="true"}}checked{{/is}} />
 	<p class="description" style="margin-left: 190px;">
-		<?php _e( 'When enabled, pings and trackbacks will be removed from the comment stream.', 'epoch' ); ?>
+		<?php _e( 'When enabled, pings and trackbacks will show in the comment stream.', 'epoch' ); ?>
 	</p>
 </div>

--- a/includes/templates/options-panel.php
+++ b/includes/templates/options-panel.php
@@ -66,3 +66,12 @@
 	</p>
 </div>
 
+<div class="epoch-config-group">
+	<label for="epoch-options-order">
+		<?php _e( 'Hide Pings & Trackbacks', 'epoch' ); ?>
+	</label>
+	<input type="checkbox" name="options[hide_pings]" value="true" {{#is options/hide_pings value="true"}}checked{{/is}} />
+	<p class="description" style="margin-left: 190px;">
+		<?php _e( 'When enabled, pings and trackbacks will be removed from the comment stream.', 'epoch' ); ?>
+	</p>
+</div>


### PR DESCRIPTION
Adds an option to show pingbacks in the comment stream and unifies the method to get the number of comments on a post, allowing for filtering out pingbacks when enabled. introduces a new filter on the get_comment_args as well, so that the comment types can be modified for custom work.

Addresses #92
