### PR TITLE
fix maybe_verify_origin function

### DIFF
--- a/classes/front/api_route.php
+++ b/classes/front/api_route.php
@@ -258,10 +258,11 @@ class api_route {
 
 			if ( $ref  ) {
 				$ref = parse_url( $ref );
+				$home_url = parse_url( home_url() );
 				if ( $ref[ 'host' ] == $_SERVER[ 'SERVER_NAME' ] ) {
 					return true;
 
-				}elseif( $ref[ 'host' ] == home_url() ) {
+				}elseif( $ref[ 'host' ] == $home_url[ 'host' ] ) {
 					return true;
 				}
 


### PR DESCRIPTION
The `maybe_verify_origin()` function has a comparison that makes no sense. It is comparing a hostname to a full URL which could never match. This patch parses the `home_url()` and then compares the host value of that to the host value from the parsed url of the request’s referrer to compare apples to apples.
